### PR TITLE
fix: plugins in lazy setup should be a table rather than a string

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -13,7 +13,7 @@ end
 vim.opt.rtp:prepend(lazypath)
 
 -- Configure lazy.nvim
-require("lazy").setup("plugins", {
+require("lazy").setup(plugins, {
   defaults = { lazy = true, version = nil },
   install = { missing = true, colorscheme = { "tokyonight", "gruvbox" } },
   checker = { enabled = true },


### PR DESCRIPTION
The first argument of setup should not be string.
error msg:

```
Error detected while processing /Users/ccyynn/.config/nv/init.lua:
No specs found for module plugins
```

BTW this error only affect 01-init.